### PR TITLE
Ignore onSelect when focusing with the mouse

### DIFF
--- a/packages/slate-react/src/plugins/dom/after.js
+++ b/packages/slate-react/src/plugins/dom/after.js
@@ -27,6 +27,7 @@ const debug = Debug('slate:after')
 function AfterPlugin(options = {}) {
   let isDraggingInternally = null
   let isMouseDown = false
+  let isFocusFromClick = false
 
   /**
    * On before input.
@@ -393,11 +394,10 @@ function AfterPlugin(options = {}) {
     // the old selection from being set by the `updateSelection` of `<Content>`,
     // preventing the `selectionchange` from firing. (2018/11/07)
     if (isMouseDown && !IS_IE && !IS_EDGE) {
-      editor.deselect().focus()
-    } else {
-      editor.focus()
+      isFocusFromClick = true
     }
 
+    editor.focus()
     next()
   }
 
@@ -669,6 +669,15 @@ function AfterPlugin(options = {}) {
     next()
   }
 
+  function focusFromClick() {
+    return isFocusFromClick
+  }
+
+  function clearFocusFromClick() {
+    isFocusFromClick = false
+    return null
+  }
+
   /**
    * Return the plugin.
    *
@@ -691,6 +700,8 @@ function AfterPlugin(options = {}) {
     onMouseUp,
     onPaste,
     onSelect,
+    queries: { focusFromClick },
+    commands: { clearFocusFromClick },
   }
 }
 

--- a/packages/slate-react/src/plugins/dom/before.js
+++ b/packages/slate-react/src/plugins/dom/before.js
@@ -459,6 +459,7 @@ function BeforePlugin() {
     if (isComposing) return
 
     if (editor.readOnly) return
+    if (editor.focusFromClick()) return
 
     // Save the new `activeElement`.
     const window = getWindow(event.target)

--- a/packages/slate-react/src/plugins/react/commands.js
+++ b/packages/slate-react/src/plugins/react/commands.js
@@ -4,6 +4,8 @@
  * @return {Object}
  */
 
+import scrollToSelectionUtil from '../../utils/scroll-to-selection'
+
 function CommandsPlugin() {
   /**
    * Takes a `node`, find the matching `domNode` and uses it to set the text
@@ -61,10 +63,18 @@ function CommandsPlugin() {
     editor.reconcileNode(node)
   }
 
+  function scrollToSelection(editor) {
+    window.requestAnimationFrame(() => {
+      const selection = window.getSelection()
+      scrollToSelectionUtil(selection)
+    })
+  }
+
   return {
     commands: {
       reconcileNode,
       reconcileDOMNode,
+      scrollToSelection,
     },
   }
 }


### PR DESCRIPTION
When focusing with the mouse, the native selectionchange event will
fire after the onSelect event. This means we will end up temporarily
setting the selection to the wrong place before moving it to the right
place. This is noticable if you start typing quickly after clicking.

On clicks, we should block onSelect until we process the click's
selection change.