### PR TITLE
Force selectionchange before updateSelection when clicking to focus

### DIFF
--- a/packages/slate-react/src/plugins/dom/before.js
+++ b/packages/slate-react/src/plugins/dom/before.js
@@ -459,7 +459,6 @@ function BeforePlugin() {
     if (isComposing) return
 
     if (editor.readOnly) return
-    if (editor.focusFromClick()) return
 
     // Save the new `activeElement`.
     const window = getWindow(event.target)


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing a bug.

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

Clicking into the editor means "set the editor's selection based on where I clicked." This means we should set the Slate selection from the browser selection, not vice versa. In code, this means we want to call onNativeSelectionChanged before updateSelection runs.

Focusing the editor calls updateSelection. Most browsers fire a selectionchanged event quickly, so the browser selection overrides updateSelection's changes. But some browsers don't.

With this change, we will not call updateSelection from a click-to-focus event until a selectionchange event is handled. This makes all browsers handle these events in the same order.

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)
