### PR TITLE
handle case where path is undefined

### DIFF
--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-react",
   "description": "A set of React components for building completely customizable rich-text editors.",
-  "version": "0.22.11-merged-backports.3",
+  "version": "0.22.11-merged-backports.4",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "lib/slate-react.js",

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-react",
   "description": "A set of React components for building completely customizable rich-text editors.",
-  "version": "0.22.11-merged-backports.4",
+  "version": "0.22.11-merged-backports.3",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "lib/slate-react.js",

--- a/packages/slate/package.json
+++ b/packages/slate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate",
   "description": "A completely customizable framework for building rich text editors.",
-  "version": "0.47.10-merged-backports.2",
+  "version": "0.47.10-merged-backports.3",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "lib/slate.js",

--- a/packages/slate/package.json
+++ b/packages/slate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate",
   "description": "A completely customizable framework for building rich text editors.",
-  "version": "0.47.10-merged-backports.3",
+  "version": "0.47.10-merged-backports.4",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "lib/slate.js",

--- a/packages/slate/src/models/point.js
+++ b/packages/slate/src/models/point.js
@@ -307,7 +307,7 @@ class Point extends Record(DEFAULTS) {
       key = path
       path = key === this.key ? this.path : null
     } else {
-      key = path.equals(this.path) ? this.key : null
+      key = (path && path.equals(this.path)) ? this.key : null
     }
 
     const point = this.merge({ key, path, offset })

--- a/packages/slate/src/models/point.js
+++ b/packages/slate/src/models/point.js
@@ -307,7 +307,7 @@ class Point extends Record(DEFAULTS) {
       key = path
       path = key === this.key ? this.path : null
     } else {
-      key = (path && path.equals(this.path)) ? this.key : null
+      key = path && path.equals(this.path) ? this.key : null
     }
 
     const point = this.merge({ key, path, offset })


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
See [Aha Feature](https://big.aha.io/features/USB-1000) - fixes an issue where path could be undefined which throws an error when we call `path.equals`

#### What's the new behavior?

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [ ] The new code matches the existing patterns and styles.
* [ ] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ ] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
