### PR TITLE
A-10734 Fix pasting text into preformatted block

### DIFF
--- a/packages/slate/src/commands/at-range.js
+++ b/packages/slate/src/commands/at-range.js
@@ -829,6 +829,7 @@ Commands.insertFragmentAtRange = (editor, range, fragment) => {
     // If the starting block is empty, we replace it entirely with the first block
     // of the fragment, since this leads to a more expected behavior for the user.
     if (
+      startBlock.type !== 'code' &&
       !editor.isVoid(startBlock) &&
       startBlock.text === '' &&
       !startBlock.findDescendant(n => editor.isVoid(n))


### PR DESCRIPTION
## Description
* Don't delete preformatted/code block if it is empty when inserting a fragment

[Aha! Feature](https://big.aha.io/develop/features/A-10734)

