### PR TITLE
AI-760-2 Try and prevent errors on Android

### DIFF
--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-react",
   "description": "A set of React components for building completely customizable rich-text editors.",
-  "version": "0.22.11-merged-backports.3",
+  "version": "0.22.11-merged-backports.4",
   "license": "MIT",
   "repository": "git://github.com/ianstormtaylor/slate.git",
   "main": "lib/slate-react.js",

--- a/packages/slate-react/src/plugins/android/composition-manager.js
+++ b/packages/slate-react/src/plugins/android/composition-manager.js
@@ -544,6 +544,17 @@ function CompositionManager(editor) {
       const domSelection = getWindow(event.target).getSelection()
       let range = editor.findRange(domSelection)
 
+      if (!range) {
+        // Sometimes on Android, especially when you first click into the editor,
+        // findRange will return null. If we don't return now, then we will
+        // encounter a worse error a few lines down. But the long term
+        // consequences of doing this are not entirely clear. The cursor does
+        // wild things on Android, maybe a result of doing this, but at least
+        // the cursor does something when we have this in there.
+        console.error("Selection was not found.");
+        return;     
+      }
+
       const anchorFix = fixTextAndOffset(
         domSelection.anchorNode.textContent,
         domSelection.anchorOffset


### PR DESCRIPTION
Sometimes when you click in to the editor (and even other times) slate fails to find the correct range. Other places return after calling findRange when it returns null, this should as well.